### PR TITLE
Recruitment task

### DIFF
--- a/cypress/integration/ticket-form.spec.ts
+++ b/cypress/integration/ticket-form.spec.ts
@@ -1,17 +1,17 @@
 // Your tests go in here. Happy coding! 🤓
 
 describe('Ticket Form', () => {
+    const licence_id = 13329102
+    const testName = 'Test Name'
+    const testEmail = 'test@email.com'
+    const testSubject = 'Test Subject'
+    const testMessage = 'Test Message'
+
     beforeEach(() => {
         cy.visit('/')
     })
 
     it('User receives Thank you! message after submitting the form with valid values', () => {
-        const licence_id = 13329102
-        const testName = 'Test Name'
-        const testEmail = 'test@email.com'
-        const testSubject = 'Test Subject'
-        const testMessage = 'Test Message'
-
         cy.intercept('POST', '/v2/tickets/new', {
             statusCode: 200,
             body: {
@@ -40,5 +40,22 @@ describe('Ticket Form', () => {
             })
         })
         cy.get('h1').should('contain', 'Thank you!')
+    })
+
+    it('User receives error message if submit request fails', () => {
+        cy.intercept('POST', '/v2/tickets/new', {
+            statusCode: 500,
+            body: {
+                error: 'Internal server error',
+            },
+        })
+
+        cy.get('#name').type(testName)
+        cy.get('#email').type(testEmail)
+        cy.get('#subject').type(testSubject)
+        cy.get('#message').type(testMessage)
+        cy.contains('button', 'Submit').click()
+
+        cy.get('h1').should('contain', 'Error!')
     })
 })

--- a/cypress/integration/ticket-form.spec.ts
+++ b/cypress/integration/ticket-form.spec.ts
@@ -1,1 +1,44 @@
 // Your tests go in here. Happy coding! 🤓
+
+describe('Ticket Form', () => {
+    beforeEach(() => {
+        cy.visit('/')
+    })
+
+    it('User receives Thank you! message after submitting the form with valid values', () => {
+        const licence_id = 13329102
+        const testName = 'Test Name'
+        const testEmail = 'test@email.com'
+        const testSubject = 'Test Subject'
+        const testMessage = 'Test Message'
+
+        cy.intercept('POST', '/v2/tickets/new', {
+            statusCode: 200,
+            body: {
+                id: 'ABCD',
+            },
+        }).as('createTicket')
+
+        cy.get('#name').type(testName)
+        cy.get('#email').type(testEmail)
+        cy.get('#subject').type(testSubject)
+        cy.get('#message').type(testMessage)
+        cy.contains('button', 'Submit').click()
+
+        cy.wait('@createTicket').then((interception) => {
+            expect(interception.request.body).to.deep.include({
+                group: 0,
+                licence_id: licence_id,
+                requester: {
+                    name: testName,
+                    mail: testEmail,
+                },
+                subject: testSubject,
+                offline_message: testMessage,
+                ticket_message: testMessage,
+                visitor_id: testEmail,
+            })
+        })
+        cy.get('h1').should('contain', 'Thank you!')
+    })
+})


### PR DESCRIPTION
Since almost all elements I interacted with have unique IDs I didn't add any `test-id` or `data-cy` attributes to the app as I felt it's not neccessary here. But it is something I would do in real-life scenario.

Same thing with page objects - I used that pattern a few times with Cypress tests but I don't know the approach at LiveChat and creators of Cypress advise against it. Since there are just two tests I felt like it is not worth doing but with more tests I would have all selectors in separate file.